### PR TITLE
Feature enhancement as per request from Nepo

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,17 @@ In the following utternaces you can do as above to change between reminder or ti
  **Additional events** :
  - Asking Alice to set a "Food Timer" will let alice know your cooking and therefore she will remind 
     you half way through the timer to check your food.
- 
+ - Alice can now set a "Timer" (only) without a message by saying things like
+    * set a quick timer for 3 minutes
+    * create a short timer for 2 minutes
+    * keywords to trigger this are : "quick", "short" "breif", "simple", "lazy"
+    and she will now set a timer event without the need for a topic
+    
+    NOTE: the limitation on this quick timer function are.
+    * if you reboot you'll loose the timer 
+    * you wont be able to stop the timer as it has no topic
+    * you won't be able to ask how longs left on the timer as it has no topic
+    * This only works for timer event, not reminder or alarm events
      
  **Sound folder**
  

--- a/Reminder.install
+++ b/Reminder.install
@@ -1,6 +1,6 @@
 {
     "name": "Reminder",
-    "version": "1.1.2",
+    "version": "1.1.3",
     "icon": "fas fa-hourglass-half",
     "category": "organisation",
     "author": "Lazza",

--- a/dialogTemplate/en.json
+++ b/dialogTemplate/en.json
@@ -4,6 +4,23 @@
     "description": "Set local reminders such as \" remind me in ten minutes to ring bob \"",
     "slotTypes": [
 		{
+			"name": "ShortTimer",
+			"matchingStrictness": null,
+			"automaticallyExtensible": true,
+			"useSynonyms": true,
+			"values": [
+				{
+					"value": "short",
+					"synonyms": [
+						"simple",
+						"quick",
+						"brief",
+						"lazy"
+					]
+				}
+			]
+		},
+		{
 			"name": "AlarmEvent",
 			"matchingStrictness": null,
 			"automaticallyExtensible": true,
@@ -245,9 +262,21 @@
 				"Set a {Timer:=>TimerEvent} for {10 minutes:=>TimerDateAndTime}",
 				"Add a {20 minute:=>TimerDateAndTime} {Timer:=>TimerEvent}",
 				"create a {Timer:=>TimerEvent} for {2 pm:=>TimerDateAndTime}",
-				"Add a {Timer:=>TimerEvent} for {4pm:=>TimerDateAndTime}"
+				"Add a {Timer:=>TimerEvent} for {4pm:=>TimerDateAndTime}",
+				"set a {short:=>ShortTimer} {timer:=>TimerEvent} for {5 minutes:=>Duration}",
+				"create a {short:=>ShortTimer} {timer:=>TimerEvent} for {7 minutes:=>Duration}",
+				"set a {quick:=>ShortTimer} {timer:=>TimerEvent} for {3 minutes:=>Duration}",
+				"set a {simple:=>ShortTimer} {timer:=>TimerEvent} for {7 minutes:=>Duration} please",
+				"add a {breif:=>ShortTimer} {timer:=>TimerEvent} for {7 minutes:=>Duration} please"
 			],
 			"slots": [
+				{
+					"name": "ShortTimer",
+					"description": null,
+					"required": false,
+					"type": "ShortTimer",
+					"missingQuestion": ""
+				},
 				{
 					"name": "TimerEvent",
 					"description": null,


### PR DESCRIPTION
- Alice can now set a "Timer" (only) without a message by saying things like
    * set a quick timer for 3 minutes
    * create a short timer for 2 minutes
    * keywords to trigger this are : "quick", "short" "breif", "simple", "lazy"
    and she will now set a timer event without the need for a topic
    
    NOTE: the limitation on this quick timer function are.
        * if you reboot you'll loose the timer 
        * you wont be able to stop the timer as it has no topic
        * you won't be able to ask how longs left on the timer as it has no topic
        * This only works for timer event, not reminder or alarm events